### PR TITLE
fix a type of 'intValue'

### DIFF
--- a/src/curi.c
+++ b/src/curi.c
@@ -160,7 +160,7 @@ static curi_status handle_query_item_decodedKey(const char* key, size_t keyLen, 
     if (valueLen != 0 && settings->query_item_int_callback)
     {
         char* valueEnd = 0;
-        long int intValue = 0;
+        long intValue = 0;
         intValue = strtol(value,&valueEnd,10); // Trying to parse an integer
         if (valueEnd == value + valueLen)
         {

--- a/src/curi.h
+++ b/src/curi.h
@@ -57,7 +57,7 @@ typedef struct
     int (*path_segment_callback)(void* userData, const char* pathSegment, size_t pathSegmentLen); //!< if not-NULL, called with the parsed path segment (default is NULL).
     int (*query_callback)(void* userData, const char* query, size_t queryLen); //!< if not-NULL, called with the parsed query (default is NULL).
     int (*query_item_null_callback)(void* userData, const char* queryItemKey, size_t queryItemKeyLen); //!< if not-NULL, called with each of the parsed query items having no value (default is NULL).
-    int (*query_item_int_callback)(void* userData, const char* queryItemKey, size_t queryItemKeyLen, long int queryItemValue); //!< if not-NULL, called with each of the parsed query items having an int value (default is NULL).
+    int (*query_item_int_callback)(void* userData, const char* queryItemKey, size_t queryItemKeyLen, long queryItemValue); //!< if not-NULL, called with each of the parsed query items having an int value (default is NULL).
     int (*query_item_double_callback)(void* userData, const char* queryItemKey, size_t queryItemKeyLen, double queryItemValue); //!< if not-NULL, called with each of the parsed query items having an double value (default is NULL).
     int (*query_item_str_callback)(void* userData, const char* queryItemKey, size_t queryItemKeyLen, const char* queryItemValue, size_t queryItemValueLen); //!< if not-NULL, called with each of the parsed query items that hasn't been handled by the previous callbacks (default is NULL).
     char query_item_separator; //!< the character separating query items (default is '&').


### PR DESCRIPTION
return type of [strtol()](http://en.cppreference.com/w/c/string/byte/strtol) is long